### PR TITLE
Fix gap between top gradient and container

### DIFF
--- a/src/components/DynamicallySelectedPicker.tsx
+++ b/src/components/DynamicallySelectedPicker.tsx
@@ -186,7 +186,7 @@ export default function DynamicallySelectedPicker({
         style={[
           styles.gradientWrapper,
           {
-            top: border.topWidth,
+            top: position.top,
             borderBottomWidth: border.bottomWidth,
             borderBottomColor: selectedItemBorderColor,
           },


### PR DESCRIPTION
There is a 1 px gap between top gradient and the container, so the list elements are visible through it. The `top` property is incorrectly set to `border.topwidth` instead of 0 (or `position.top`)